### PR TITLE
Mark nautilus as end-of-life

### DIFF
--- a/flathub.json
+++ b/flathub.json
@@ -1,0 +1,3 @@
+{
+    "end-of-life": "Nautilus is improving Flatpak integration before delivering it as stable, in the meantime the maintainers encourage you to test the development version from https://sdk.gnome.org/gnome-apps-nightly.flatpakrepo"
+}

--- a/org.gnome.Nautilus.json
+++ b/org.gnome.Nautilus.json
@@ -1,5 +1,5 @@
 {
-    "app-id": "org.gnome.NautilusStableFlatpak",
+    "app-id": "org.gnome.Nautilus",
     "runtime": "org.gnome.Platform",
     "runtime-version": "3.28",
     "sdk": "org.gnome.Sdk",
@@ -90,8 +90,7 @@
             "builddir": true,
             "name": "nautilus",
             "config-opts": [
-                "--libdir=/app/lib",
-                "-Dprofile=stable-flatpak"
+                "--libdir=/app/lib"
             ],
             "sources": [
                 {


### PR DESCRIPTION
This also renames it back to org.gnome.Nautilus so it will build.